### PR TITLE
Fix issue#1 move Message.set_header() Message.set_payload() to __init__

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,7 +40,5 @@ if __name__ == "__main__":
                     message_type=LOGIN, 
                     data="user\npassword\n1234"
                   )
-        message.set_payload()
-        message.set_header()
         server_response = p.send_message(message)
         print(server_response._data)

--- a/message/message_base.py
+++ b/message/message_base.py
@@ -4,6 +4,8 @@ from .message import Message
 class MessageBase(Message):
     def __init__(self, mtype,  data):
         super().__init__(mtype, data)
+        self.set_payload()
+        self.set_header()
 
     def get_payload(self):
         pass

--- a/server/server.py
+++ b/server/server.py
@@ -28,8 +28,6 @@ class Server:
             # process message from peer (decode and do some actions) and sent 
             # back a response
             output_message = MessagesFactory.create(LOGIN_OK, "LOGIN_OK")
-            output_message.set_payload()
-            output_message.set_header()
             new_session.send_message(output_message)
         new_session.disconnect()
         print("[*] Disconnected sesssion")


### PR DESCRIPTION
ref: https://github.com/kinderp/beer2beer/issues/1 des: Make implicit set_header()
     and set_payload() on Messa
     ges' classes

We don't need  anymore to  call set_header() and
set_payload()  from  caller  after a new message
instance has been created, those have been moved
inside __init_ method of MessageBase class.