### PR TITLE
Add a raw storage class

### DIFF
--- a/server/storage.py
+++ b/server/storage.py
@@ -1,0 +1,48 @@
+import shelve
+
+from settings import ShellSettings
+
+DB_NAME = "storage.bin"
+DB_SETTINGS = ShellSettings.DIRECTORY_SETTINGS + "/" + DB_NAME
+
+
+class Peer:
+    def __init__(self, username, md5pwd, status, contents_list=[]):
+        self.username = username
+        self.md5pwd = md5pwd
+        self.status = status
+        self.contents_list = contents_list
+
+    def set_status(self, status):
+        self.status = status
+
+    def set_contents_list(self, c_list):
+        self.contents_list = c_list
+
+
+class Content:
+    def __init__(self, filename, dimension, sha1):
+        self.filename = filename
+        self.dimension = dimension
+        self.sha1 = sha1
+
+
+class Storage:
+    db = None
+
+    @classmethod
+    def load(cls):
+        cls.db = shelve.open(DB_SETTINGS)
+
+    @classmethod
+    def save(cls):
+        if cls.db:
+            cls.db.close()
+        
+    @classmethod
+    def add_row(cls, index, row):
+        cls.db[index] = row
+
+    @classmethod
+    def del_row(cls, index):
+        del cls.db[index]


### PR DESCRIPTION
We added in server/storage module
3 new classes:

* Content: it is a sharing content
	 - filename
	 - dimension
	 - sha1

* Peer   : it is a peer in our db
	 - username
	 - password
	 - status (online/offline)
	 - contents_list (a list of Content objects)

* Storage: it is our shelve database

How to use these storage classes:

```python

from server.storage import *

Storage.load()
Storage.db
list(Storage.db.keys())
list(Storage.db.values())
list(Storage.db.items())

Storage.db['5']
Storage.db['5'].username
Storage.db['5'].contents_list

```