### PR TITLE
Fix static user_id in register command

### DIFF
--- a/command/command_register.py
+++ b/command/command_register.py
@@ -1,5 +1,7 @@
 from .command import Command
 from receiver.receiver_register import ReceiverRegister
+from message.messages_codes import REGISTER_OK, REGISTER_KO
+from settings import ShellSettings
 
 
 class CommandRegister(Command):
@@ -8,8 +10,12 @@ class CommandRegister(Command):
 
     def execute(self, args=None):
         response = self.__receiver.register()
-        # add here some login to check response
-        # and return something to the caller
-        pass
-        
+        response.unpack() # we need to convert raw payload into high-level one
+        if response._mtype == REGISTER_OK:
+            if response.id:
+                ShellSettings.USER_ID = response.id
+                return True
+            return False
+        if response._mtype == REGISTER_KO:
+            return False
 

--- a/message/message_register.py
+++ b/message/message_register.py
@@ -1,6 +1,33 @@
 from .message_base import MessageBase
 from server.storage import Content
 
+
+class MessageRegisterOk(MessageBase):
+    def __init__(self, mtype, data):
+        super().__init__(mtype, data)
+        self.message_response = None
+        self.id = None
+
+    def set_payload(self):
+        super().set_payload()
+
+    def set_header(self):
+        super().set_header()
+    
+    def pack(self):
+        return super().pack()
+
+    def unpack(self):
+        register_tokens = self._data.split()
+        if register_tokens:
+            # TODO: we'd like to check out of index
+            # in case our client is sending  a  bad
+            # formatted input message (e.g. missing
+            # id)
+            self.message_response = register_tokens.pop(0)
+            self.id = register_tokens.pop(0)
+             
+
 class MessageRegister(MessageBase):
     def __init__(self, mtype, data):
         super().__init__(mtype, data)

--- a/message/messages_factory.py
+++ b/message/messages_factory.py
@@ -5,7 +5,7 @@ from .messages_codes import REGISTER
 from .messages_codes import REGISTER_OK
 from .messages_codes import REGISTER_KO
 from .message_login import MessageLogin
-from .message_register import MessageRegister
+from .message_register import MessageRegister, MessageRegisterOk
 
 
 class MessagesFactory:
@@ -14,7 +14,7 @@ class MessagesFactory:
         LOGIN_OK: MessageLogin,
         LOGIN_KO: MessageLogin,
         REGISTER: MessageRegister,
-        REGISTER_OK: MessageRegister,
+        REGISTER_OK: MessageRegisterOk,
         REGISTER_KO: MessageRegister,
     }
 

--- a/settings.py
+++ b/settings.py
@@ -36,6 +36,7 @@ class ShellSettings:
     """
     USERNAME = None
     PASSWORD = None
+    USER_ID = None
     DIRECTORY = None
     DIRECTORY_SETTINGS = ".beer2beer"
     SERVER_HOST = "localhost"

--- a/shell/shell.py
+++ b/shell/shell.py
@@ -51,6 +51,7 @@ class Beer2BeerShell(cmd.Cmd):
     def do_show(self, arg):
         print("USERNAME  => ", ShellSettings.USERNAME)
         print("PASSWORD  => ", ShellSettings.PASSWORD)
+        print("USER_ID => ", ShellSettings.USER_ID)
         print("DIRECTORY => ", ShellSettings.DIRECTORY)
         print("DIRECTORY SETTINGS => ", ShellSettings.DIRECTORY_SETTINGS)
         print("SERVER HOSTNAME => ", ShellSettings.SERVER_HOST)
@@ -120,10 +121,13 @@ class Beer2BeerShell(cmd.Cmd):
         print(help_string)
 
     def do_login(self, arg):
+        if not ShellSettings.USER_ID:
+            print("ERROR: id not set, did you make a registration?!")
+            return False
         arg = self.parse(arg)
         result, user, pwd = self.parse_login(arg)
         if not result: return False
-        login_payload = "{}\n{}\n{}".format(user, pwd, "1")
+        login_payload = "{}\n{}\n{}".format(user, pwd, ShellSettings.USER_ID)
         login_command = CommandLogin(
                 ShellSettings.SERVER_HOST, ShellSettings.SERVER_PORT, login_payload)
         response = login_command.execute()
@@ -170,7 +174,6 @@ class Beer2BeerShell(cmd.Cmd):
         register_command = CommandRegister(
                 ShellSettings.SERVER_HOST, ShellSettings.SERVER_PORT, register_payload)
         response = register_command.execute()
-        print(arg)
 
     def parse_register(self, arg):
         if len(arg) == 3:


### PR DESCRIPTION
Before this PR user_id in login call was static in the code.
Now we retrieve user_id after a register call and set that value in ShellSettings.USER_ID.
This stored value will be dynamically retrieved in a login call.

How to test:

1. python clear_db.py
2. python main.py server
3. python main.py shell
4. register uno 1234 .
5. login uno 1234